### PR TITLE
Remove return for functions with return type void

### DIFF
--- a/base/MQ/policies/Serialization/BoostSerializer.h
+++ b/base/MQ/policies/Serialization/BoostSerializer.h
@@ -93,7 +93,7 @@ class BoostSerializer : public BaseSerializationPolicy<BoostSerializer<DataType,
 
     void GetMessage()
     {
-        return fMessage;
+        /* return fMessage; */
     }
 
     void Init()
@@ -285,7 +285,7 @@ class BoostDeSerializer : public BaseSerializationPolicy<BoostDeSerializer<DataT
 
     void GetMessage()
     {
-        return fMessage;
+        /* return fMessage; */
     }
 
     void Init()


### PR DESCRIPTION
Hi Thomas,

Here the last issue I found with GCC 6:
The compiler objects to returning in void functions. Removing the return trivially fixes this.

As far as I can tell the functions are not actually used in any FairRoot/FairShip code, so depending on intended behaviour we could also change the return value of the functions to correspond to the values being returned. Similar functions in FairRoot often return pointers to the message, if that is of relevance.

Cheers,

Oliver 