### PR TITLE
Backport for ROOT 6.14/06: Fixes in FairDetector and FairTutorialDet4.cxx:

### DIFF
--- a/base/sim/FairDetector.cxx
+++ b/base/sim/FairDetector.cxx
@@ -84,32 +84,11 @@ FairDetector::FairDetector()
 
 // -------------------------------------------------------------------------
 
-void FairDetector::DefineSensitiveVolumes()
-{
-  TObjArray* volumes = gGeoManager->GetListOfVolumes();
-  TIter next(volumes);
-  TGeoVolume* volume;
-  while ( ( volume = static_cast<TGeoVolume*>(next()) ) ) {
-    if ( CheckIfSensitive(volume->GetName()) ) {
-      LOG(debug2)<<"Sensitive Volume "<< volume->GetName();
-      AddSensitiveVolume(volume);
-    }
-  }
-}
-
-// -------------------------------------------------------------------------
-
 void   FairDetector::Initialize()
 {
 // Registers hits collection in Root manager;
 // sets sensitive volumes.
 // ---
-
-  // Define sensitive volumes if in MT
-  if ( gMC->IsMT() ) {
-    std::cout << "Define sensitive volume " << std::endl;
-    DefineSensitiveVolumes();
-  }
 
   Int_t NoOfEntries=svList->GetEntries();
   Int_t fMCid;

--- a/base/sim/FairDetector.h
+++ b/base/sim/FairDetector.h
@@ -105,8 +105,6 @@ class FairDetector : public FairModule
     /** Assignment operator */
     FairDetector& operator= (const FairDetector&);
 
-    virtual void DefineSensitiveVolumes();
-
     Int_t fDetId; // Detector Id has to be set from ctr.
     FairLogger* fLogger;  //! /// FairLogger
 

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
@@ -360,8 +360,12 @@ void FairTutorialDet4::ModifyGeometryByFullPath()
 
     TGeoRotation* rrot = new TGeoRotation("rot",dphi,dtheta,dpsi);
     TGeoCombiTrans localdelta = *(new TGeoCombiTrans(dx,dy,dz, rrot));
+    TGeoHMatrix l3m = TGeoHMatrix(*l3);
+    TGeoHMatrix ldm = TGeoHMatrix(localdelta);
+
 //      localdelta.Print();
-    TGeoHMatrix nlocal = *l3 * localdelta;
+    // TGeoHMatrix nlocal = *l3 * localdelta;
+    TGeoHMatrix nlocal = l3m * ldm;
     TGeoHMatrix* nl3 = new TGeoHMatrix(nlocal); // new matrix, representing real position (from new local mis RS to the global one)
 
     TGeoPhysicalNode* pn3 = gGeoManager->MakePhysicalNode(volPath);
@@ -414,7 +418,10 @@ void FairTutorialDet4::ModifyGeometryBySymlink()
     TGeoRotation* rrot = new TGeoRotation("rot",dphi,dtheta,dpsi);
     TGeoCombiTrans localdelta = *(new TGeoCombiTrans(dx,dy,dz, rrot));
     localdelta.Print();
-    TGeoHMatrix nlocal = *l3 * localdelta;
+    TGeoHMatrix l3m = TGeoHMatrix(*l3);
+    TGeoHMatrix ldm = TGeoHMatrix(localdelta);
+    // TGeoHMatrix nlocal = *l3 * localdelta;
+    TGeoHMatrix nlocal = l3m * ldm;
     TGeoHMatrix* nl3 = new TGeoHMatrix(nlocal); // new matrix, representing real position (from new local mis RS to the global one)
 
     node->Align(nl3);


### PR DESCRIPTION
- Removed FairDetector::DefineSensitiveVolumes() not needed and causing warning in MT mode
- Fixed FairTutorialDet4.cxx compilation with ROOT 6.14/04

These fixes are in FairRoot:dev and are needed to build FairRoot with ROOT newer than 6.14/02. Instead of backporting we could also move to newer FairRoot versions, but that would require more changes.